### PR TITLE
[BCGOVWILD-59] The bridge is saved as new one after editing it

### DIFF
--- a/app/BCWildlife/screens/Animals/AnimalFormScreen.js
+++ b/app/BCWildlife/screens/Animals/AnimalFormScreen.js
@@ -46,6 +46,7 @@ const AnimalFormScreen = ({route, navigation}) => {
     () => (currentAnimalId ? 'Edit' : 'Create'),
     [currentAnimalId],
   );
+  const isCreating = !currentAnimalId;
 
   const fillForm = useCallback(() => {
     if (!currentAnimal) {
@@ -87,6 +88,7 @@ const AnimalFormScreen = ({route, navigation}) => {
             <InputLabel>ID</InputLabel>
             <TextInput
               value={form.id}
+              editable={isCreating}
               onChangeText={value =>
                 setForm(draft => {
                   draft.id = value;

--- a/app/BCWildlife/screens/Bridges/BridgeFormScreen.js
+++ b/app/BCWildlife/screens/Bridges/BridgeFormScreen.js
@@ -82,6 +82,7 @@ const BridgeFormScreen = ({route}) => {
     () => (currentBridge ? 'Edit' : 'Create'),
     [currentBridge],
   );
+  const isCreating = currentBridge == null;
 
   const setDefaultValues = useCallback(() => {
     setForm(draft => {
@@ -198,6 +199,7 @@ const BridgeFormScreen = ({route}) => {
               <InputLabel>MOT Bridge ID</InputLabel>
               <TextInput
                 value={form.motBridgeId}
+                editable={isCreating}
                 onChangeText={value =>
                   setForm(draft => {
                     draft.motBridgeId = value;


### PR DESCRIPTION
Problem state:
Surprising behavior: if the user edits a bridge and an animal and changes the ID, a new bridge (resp., animal) is created.

Problem reason:
IDs are used to uniquely identify bridges and animals, so changing the ID is interpreted as creating a new entity.

Detected in the branch:
main

Conditions to reproduce the issue:
Open an existing bridge or animal for editing, change MOT ID (resp., ID), go back twice, then see the list of bridges (resp. animals).

Possible workarounds without the fix:
Don't ever edit IDs.

Changes:
Disable changing IDs in "Edit" mode.

Committed into: 73b05f22110ae0dfc8faea6d328927070675d084

Risk factors:
"Bridge Form" and "Animal Form" screens.

Risk:
Low.
