### PR TITLE
[BCGOVWILD-36] Telemetry: error message fixed

### DIFF
--- a/app/BCWildlife/screens/TelemetryFormScreen.js
+++ b/app/BCWildlife/screens/TelemetryFormScreen.js
@@ -29,7 +29,6 @@ const TelemetryFormScreen = ({navigation}) => {
     const [useTriangulation,setUseTriangulation] = useState('');
     const [comments, setComments] = React.useState('');
     const [recordIdentifier, setRecordIdentifier] = React.useState('');
-    const [triangulationText, setTriangulationText] = React.useState('');
 
 
   useEffect(() => {
@@ -208,7 +207,7 @@ const TelemetryFormScreen = ({navigation}) => {
         return;
     }
     if(!ambientTemprature){
-        Alert.alert('Please enter ambient temprature');
+        Alert.alert('Please enter ambient temperature');
         return;
     }
     if(!cloudCover){
@@ -228,19 +227,13 @@ const TelemetryFormScreen = ({navigation}) => {
         return;
 
     }
-    if(!comments){
-        comments='';
-    }
+    const location_comments = comments || '';
     if(!useTriangulation){
         Alert.alert('Please select use triangulation');
         return;
     }
 
-    if(getTelemetryStr() == ''){
-      // do nothing
-    }else{
-      setTriangulationText(getTelemetryStr());
-    }
+    const triangulation = useTriangulation === 'yes' ? getTelemetryStr() : null;
 
     const data = {
       date: dateTime,
@@ -255,11 +248,10 @@ const TelemetryFormScreen = ({navigation}) => {
       precip: precipitation,
       wind: windSpeed,
       element_identified: elementIdentified,
-      location_comments: comments,
-      triangulation:triangulationText
+      location_comments,
+      triangulation,
     };
     var recordsValue = JSON.stringify(data);
-    console.log(recordsValue);
     var timeNowEpoch = Math.round((new Date()).getTime() / 1000);
         console.log(timeNowEpoch);
         var username = getUsernameG();

--- a/app/BCWildlife/screens/TelemetryTriangulation.js
+++ b/app/BCWildlife/screens/TelemetryTriangulation.js
@@ -26,6 +26,7 @@ const TelemetryTriangulationScreen = () => {
   const handleTriangulate = () => {
     console.log('Triangulate button pressed');
     console.log(entries);
+    setTelemetryStr(entries);
 
 
 // Define constants and variables

--- a/backend/src/apis/sync/service/pushers.js
+++ b/backend/src/apis/sync/service/pushers.js
@@ -17,8 +17,28 @@ const pushChangesUpdatingModel =
       { record_identifier: data.record_identifier },
     );
 
+const addDataTransform = (pusher, dataTransform) => async (data, options) => {
+  const transformedData = dataTransform(data);
+  await pusher(transformedData, options);
+};
+
+/* eslint-disable node/no-unsupported-features/es-syntax */
+const parseTelemetryTriangulations = (data) => {
+  let { triangulation } = data.data;
+  if (triangulation === "") {
+    triangulation = [];
+  }
+  return {
+    ...data,
+    data: { ...data.data, triangulation },
+  };
+};
+
 const pushers = {
-  TELE: pushChangesUpdatingModel(Telemetry),
+  TELE: addDataTransform(
+    pushChangesUpdatingModel(Telemetry),
+    parseTelemetryTriangulations,
+  ),
   CAM: pushChangesUpdatingModel(CameraTrapData),
   BRIDGE: syncBridges,
   BAT: syncBats,


### PR DESCRIPTION
Problem reason:
Empty triangulation string sent to the server was not interpreted properly.

Detected in the branch:
main

Conditions to reproduce the issue:
Create and submit a "Telemetry Data" report.

Possible workarounds without the fix:
Unknown

Changes:
1. FE internally saves triangulation when "Add entry" and "Triangulate" buttons are pressed.
2. Correct triangulation value (possibly empty string) is sent to BE if "use triangulation" is selected.  Otherwise, "null" triangulation is sent.
3. BE interprets the empty string as an empty array of triangulation entries.
4. Code causing errors on empty comments is corrected.
Committed into:
715bf6ded5cafbdb0cc6811b71781a07de5671e6

Risk factors:
"Telemetry" and "Telemetry Triangulation" screens.

Risk:
Low.