### PR TITLE
[BCGOVWILD-96] [Bridges list][Animals list] The Bridge/Animal isn't displayed in the list right after its creation.

### DIFF
--- a/app/BCWildlife/screens/Animals/AnimalListScreen.js
+++ b/app/BCWildlife/screens/Animals/AnimalListScreen.js
@@ -6,8 +6,9 @@ import LoadingOverlay from '../../utility/LoadingOverlay';
 import {useCardListStyles} from '../../shared/styles/card-list-styles';
 import {useAnimals} from './use-animals';
 import {SimpleScreenHeader} from '../../shared/components/SimpleScreenHeader';
+import {useIsFocused} from '@react-navigation/native';
 
-const AnimalListScreen = ({navigation}) => {
+const AnimalListContainer = ({navigation}) => {
   const [loading, setLoading] = useState(false);
   const {
     animals,
@@ -68,6 +69,13 @@ const AnimalListScreen = ({navigation}) => {
       <LoadingOverlay loading={loading || loadingAnimals} />
     </View>
   );
+};
+
+// Destroy the container when unfocused in order to reinitialize the state
+// after an animal is added/edited.
+const AnimalListScreen = props => {
+  const isFocused = useIsFocused();
+  return isFocused && <AnimalListContainer {...props} />;
 };
 
 export default AnimalListScreen;

--- a/app/BCWildlife/screens/Bridges/BridgesListScreen.js
+++ b/app/BCWildlife/screens/Bridges/BridgesListScreen.js
@@ -21,6 +21,7 @@ const BridgeListContainer = ({navigation}) => {
     },
     ...cardListStyles,
   });
+  console.debug('bridges', bridges);
 
   useEffect(() => {
     const load = async () => {
@@ -93,9 +94,11 @@ const BridgeListContainer = ({navigation}) => {
   );
 };
 
-const BridgeListScreen = (props) => {
+// Destroy the container when unfocused in order to reinitialize the state
+// after a bridge is added/edited.
+const BridgeListScreen = props => {
   const isFocused = useIsFocused();
   return isFocused && <BridgeListContainer {...props} />;
-}
+};
 
 export default BridgeListScreen;

--- a/app/BCWildlife/screens/Bridges/BridgesListScreen.js
+++ b/app/BCWildlife/screens/Bridges/BridgesListScreen.js
@@ -3,13 +3,11 @@ import {View, Text, TouchableOpacity, StyleSheet, Alert} from 'react-native';
 import LoadingOverlay from '../../utility/LoadingOverlay';
 import {ScrollView} from 'react-native-gesture-handler';
 import {useCardListStyles} from '../../shared/styles/card-list-styles';
-import {GoBackArrowButton} from '../../shared/components/GoBackArrowButton';
-import {BCWildLogo} from '../../shared/components/BCWildLogo';
-import {TitleText} from '../../shared/components/TitleText';
 import {useBridges} from '../../shared/hooks/use-bridges/useBridges';
 import {SimpleScreenHeader} from '../../shared/components/SimpleScreenHeader';
+import {useIsFocused} from '@react-navigation/native';
 
-const BridgeListScreen = ({navigation}) => {
+const BridgeListContainer = ({navigation}) => {
   const [loading, setLoading] = useState(true);
   const [bridges, setBridges] = useState([]);
   const {bridgeList, bridgeByMotId} = useBridges();
@@ -94,5 +92,10 @@ const BridgeListScreen = ({navigation}) => {
     </View>
   );
 };
+
+const BridgeListScreen = (props) => {
+  const isFocused = useIsFocused();
+  return isFocused && <BridgeListContainer {...props} />;
+}
 
 export default BridgeListScreen;

--- a/app/BCWildlife/screens/Bridges/BridgesListScreen.js
+++ b/app/BCWildlife/screens/Bridges/BridgesListScreen.js
@@ -21,7 +21,6 @@ const BridgeListContainer = ({navigation}) => {
     },
     ...cardListStyles,
   });
-  console.debug('bridges', bridges);
 
   useEffect(() => {
     const load = async () => {

--- a/app/BCWildlife/screens/transect/Input.js
+++ b/app/BCWildlife/screens/transect/Input.js
@@ -48,8 +48,9 @@ const InputChoice = ({inputConfig}) => {
   );
 };
 
-const InputDate = ({inputConfig}) => {
-  const {name, displayName, hint} = inputConfig;
+// Single input either for date or for time
+const InputDateOrTime = ({inputConfig}) => {
+  const {name, displayName, hint, textFormat, mode} = inputConfig;
   const {styles, form, setForm} = useSimpleFormContext();
   return (
     <View style={styles.inputContainer}>
@@ -57,7 +58,8 @@ const InputDate = ({inputConfig}) => {
       {hint && <Text>{hint}</Text>}
       <DateTimePicker
         value={new Date(form[name])}
-        mode="date"
+        mode={mode || 'date'}
+        textFormat={textFormat}
         onChange={date =>
           setForm(draft => {
             draft[name] = date.getTime();
@@ -68,10 +70,78 @@ const InputDate = ({inputConfig}) => {
   );
 };
 
+// Two inputs, one for date, another for time
+const InputDateTime = ({inputConfig}) => {
+  const {
+    name,
+    displayNameDate,
+    displayNameTime,
+    hint,
+    dateTextFormat,
+    timeTextFormat,
+  } = inputConfig;
+  const {styles, form, setForm} = useSimpleFormContext();
+  const value = new Date(form[name]);
+  return (
+    <View style={styles.inputContainer}>
+      {hint && <Text>{hint}</Text>}
+      <View
+        // eslint-disable-next-line react-native/no-inline-styles
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 8,
+        }}>
+        <View style={styles.inputContainer}>
+          <InputLabel>{displayNameDate}</InputLabel>
+          <DateTimePicker
+            value={value}
+            mode="date"
+            onChange={date =>
+              setForm(draft => {
+                const newDate = new Date(value);
+                newDate.setFullYear(date.getFullYear());
+                newDate.setMonth(date.getMonth());
+                newDate.setDate(date.getDate());
+                newDate.setSeconds(0, 0);
+                draft[name] = newDate.getTime();
+              })
+            }
+            textFormat={dateTextFormat}
+          />
+        </View>
+        <View style={styles.inputContainer}>
+          <InputLabel>{displayNameTime}</InputLabel>
+          <DateTimePicker
+            value={value}
+            mode="time"
+            onChange={date =>
+              setForm(draft => {
+                const newDate = new Date(value);
+                newDate.setHours(date.getHours());
+                newDate.setMinutes(date.getMinutes());
+                newDate.setSeconds(0, 0);
+                draft[name] = newDate.getTime();
+              })
+            }
+            textFormat={timeTextFormat}
+          />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const InputTimestamp = ({inputConfig}) => {
+  const mode = inputConfig.mode || 'date';
+  const I = mode === 'datetime' ? InputDateTime : InputDateOrTime;
+  return <I inputConfig={inputConfig} />;
+};
+
 const InputTypes = {
   text: InputText,
   choice: InputChoice,
-  date: InputDate,
+  timestamp: InputTimestamp,
 };
 
 export const Input = ({inputConfig}) => {

--- a/app/BCWildlife/screens/transect/config.js
+++ b/app/BCWildlife/screens/transect/config.js
@@ -38,20 +38,25 @@ export const transectConfig = {
     {
       name: 'dateTime',
       databaseFieldName: 'Date_Time',
-      displayName: 'Date Time',
+      displayNameDate: 'Date',
+      displayNameTime: 'Time',
       type: 'date',
       optional: false,
-      inputType: 'text',
-      editable: false,
-      defaultValue: ({timestamp}) => {
-        const date = new Date(timestamp);
+      inputType: 'timestamp',
+      mode: 'datetime',
+      editable: true,
+      dateTextFormat: date => {
         const dd = date.getDate().toString().padStart(2, '0');
-        const mm = date.getMonth().toString().padStart(2, '0');
+        const mm = (date.getMonth() + 1).toString().padStart(2, '0');
         const yyyy = date.getFullYear();
-        const HH = date.getHours().toString().padStart(2, '0');
-        const MM = date.getMinutes().toString().padStart(2, '0');
-        return `${dd}-${mm}-${yyyy} ${HH}:${MM}`;
+        return `${dd}-${mm}-${yyyy}`;
       },
+      timeTextFormat: date => {
+        const hh = date.getHours().toString().padStart(2, '0');
+        const mm = date.getMinutes().toString().padStart(2, '0');
+        return `${hh}:${mm}`;
+      },
+      defaultValue: ({timestamp}) => timestamp,
     },
     {
       name: 'transectId',
@@ -64,7 +69,7 @@ export const transectConfig = {
       defaultValue: ({initials, timestamp, transectNumber}) => {
         const date = new Date(timestamp);
         const dd = date.getDate().toString().padStart(2, '0');
-        const mm = date.getMonth().toString().padStart(2, '0');
+        const mm = (date.getMonth() + 1).toString().padStart(2, '0');
         const yyyy = date.getFullYear();
         const transect = transectNumber.toString().padStart(2, '0');
         return `${initials}_${dd}${mm}${yyyy}_${transect}`;
@@ -131,7 +136,14 @@ export const transectConfig = {
       displayName: 'Date Last Snow',
       type: 'date',
       optional: false,
-      inputType: 'date',
+      inputType: 'timestamp',
+      mode: 'date',
+      textFormat: date => {
+        const dd = date.getDate().toString().padStart(2, '0');
+        const mm = (date.getMonth() + 1).toString().padStart(2, '0');
+        const yyyy = date.getFullYear();
+        return `${dd}-${mm}-${yyyy}`;
+      },
       editable: true,
       defaultValue: ({timestamp}) => timestamp,
       ifForm: form => form.surveyType === snowTrackSurveyType,
@@ -437,7 +449,7 @@ export const encounterConfig = {
       }) => {
         const date = new Date(timestamp);
         const dd = date.getDate().toString().padStart(2, '0');
-        const mm = date.getMonth().toString().padStart(2, '0');
+        const mm = (date.getMonth() + 1).toString().padStart(2, '0');
         const yyyy = date.getFullYear();
         const transect = transectNumber.toString().padStart(2, '0');
         const stand = standId.toString().padStart(2, '0');

--- a/app/BCWildlife/shared/components/DateTimePicker.js
+++ b/app/BCWildlife/shared/components/DateTimePicker.js
@@ -16,6 +16,7 @@ export const DateTimePicker = ({
   value,
   mode = 'date',
   containerStyle,
+  textFormat,
   textStyle,
   onChange,
 }) => {
@@ -34,6 +35,9 @@ export const DateTimePicker = ({
   );
 
   const formattedValueText = useMemo(() => {
+    if (textFormat != null) {
+      return textFormat(value);
+    }
     switch (mode) {
       case 'date':
         return value.toLocaleDateString();
@@ -42,7 +46,7 @@ export const DateTimePicker = ({
       default:
         return value.toLocaleString();
     }
-  }, [value, mode]);
+  }, [value, mode, textFormat]);
 
   return (
     <>


### PR DESCRIPTION
Problem reason:
Navigation does not destroy the screens, so the internal state of the
lists is preserved.  For example, if the user creates a bridge and goes
back to the Bridge List, the Bridge List still displays outdated list
of bridges stored in its local state.

Detected in the branch:
main

Conditions to reproduce the issue:
Go to the Bridge List, add a bridge and go back to the Bridge List.
The newly created bridge does not appear in the list.  Same for editing
the name of the bridge.  Same for Animal List.

Possible workarounds without the fix:
Go to Dashboad and return to the Bridge List; the updated list is
displayed.

Changes:
Use the isFocused hook and destroy the stateful component when the
Bridge List looses focus.  Thus, the state is reinitialized when the
user is back.  Same for animals.

Committed into:
c204d8bbf99f3908c92696b33da14e8556dad3f9

Risk factors:
Bridge List, Bridge Form, Animal List, Animal Form.

Risk:
Medium.

Recommendations for QA:
Please make sure that the fix works properly on iOS.
